### PR TITLE
Needs GHC >= 7.6

### DIFF
--- a/instant-generics.cabal
+++ b/instant-generics.cabal
@@ -32,7 +32,7 @@ source-repository head
 
 library
   hs-source-dirs:         src
-  build-depends:          base >= 3.0 && < 5, template-haskell >= 2.4 && < 3,
+  build-depends:          base >= 4.6 && < 5, template-haskell >= 2.4 && < 3,
                           containers < 1.0, syb < 1.0
   exposed-modules:        Generics.Instant,
                           Generics.Instant.Base,


### PR DESCRIPTION
```
[1 of 9] Compiling Generics.Instant.Base ( src/Generics/Instant/Base.hs, dist/dist-sandbox-fbfa3742/build/Generics/Instant/Base.o )

src/Generics/Instant/Base.hs:103:34: parse error on input `k1'
```
